### PR TITLE
shuffle describe blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "test": "npm run mocha",
     "pretest": "npm run lint",
-    "random": "node bin/rocha.js spec/tricky-spec.js",
+    "random": "node bin/rocha.js spec/tricky-spec.js spec/tricky-describe-spec.js",
     "mocha": "mocha src/*-spec.js spec/**/*-spec.js spec/fixed-spec.js",
     "lint": "standard --verbose bin/*.js *.js src/*.js spec/*.js",
     "commit": "commit-wizard",

--- a/spec/tricky-describe-spec.js
+++ b/spec/tricky-describe-spec.js
@@ -1,0 +1,16 @@
+/* global describe, it */
+
+describe('tricky describe example', function () {
+  var foo
+  describe('in environment 1', function () {
+    it('runs a test', function () {
+      foo = 42
+      console.log('polluted the environment')
+    })
+  })
+  describe('in environment 2', function () {
+    it('runs a test', function () {
+      console.assert(foo === 42, 'foo is 42', foo)
+    })
+  })
+})

--- a/src/order-of-tests.js
+++ b/src/order-of-tests.js
@@ -3,6 +3,16 @@ const la = require('lazy-ass')
 const is = require('check-more-types')
 const _ = require('lodash')
 
+function shuffleDescribes (suite) {
+  if (suite.suites && suite.suites.length) {
+    log('shuffling %d describe blocks in "%s"',
+      suite.suites.length, suite.title)
+    suite.suites = _.shuffle(suite.suites)
+    shuffleTests(suite)
+    suite.suites.forEach(shuffleDescribes)
+  }
+}
+
 function shuffleTests (suite) {
   if (suite.tests.length) {
     log('shuffling %d unit tests in "%s"',
@@ -60,7 +70,7 @@ function setOrder (suite, order) {
 }
 
 module.exports = {
-  shuffle: shuffleTests,
+  shuffle: shuffleDescribes,
   set: setOrder,
   collect: collectTestOrder
 }


### PR DESCRIPTION
The current implementation of rocha will shuffle the execution order of `it` blocks within each `describe` block, but the `describe` blocks are run in the order in which they're written.

This PR shuffles the execution order of the `describe` blocks themselves, in order to expose any test dependencies between them.