### PR TITLE
feat(deps): Allow passing mocha as an external dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 const Mocha = require('mocha')
-const mocha = new Mocha()
 const log = require('debug')('rocha')
 // verbose output during e2e tests
 const e2e = require('debug')('rocha:e2e')
@@ -13,6 +12,8 @@ la(is.object(cache), 'missing test order object')
 
 function rocha (options) {
   options = options || {}
+
+  const mocha = options.mocha || new Mocha()
 
   log('starting rocha with options')
   log(JSON.stringify(options, null, 2))


### PR DESCRIPTION
Allows passing a `mocha` instance instead of creating a new one.

This allows the use case of passing an external mocha with configured reports, for example.

```
const rocha = require('rocha');
const mocha = new Mocha();
mocha.reporter(myReporter);

rocha({ spec: "file.js", mocha: mocha });
```
