### PR TITLE
Use object shorthand for properties

### DIFF
--- a/bin/rocha.js
+++ b/bin/rocha.js
@@ -13,11 +13,11 @@ const help = [
 require('simple-bin-help')({
   minArguments: 3,
   packagePath: join(__dirname, '..', 'package.json'),
-  help: help
+  help
 })
 
 // console.log(process.argv)
 
 const spec = process.argv.slice(2)
 const rocha = require('..')
-rocha({ spec: spec })
+rocha({ spec })

--- a/src/order-of-tests-spec.js
+++ b/src/order-of-tests-spec.js
@@ -1,7 +1,7 @@
 const la = require('lazy-ass')
 const is = require('check-more-types')
 const _ = require('lodash')
-const {set, shuffle} = require('./order-of-tests')
+const { set, shuffle } = require('./order-of-tests')
 const snapshot = require('snap-shot')
 const R = require('ramda')
 

--- a/src/order-of-tests.js
+++ b/src/order-of-tests.js
@@ -2,10 +2,10 @@ const log = require('debug')('rocha')
 const la = require('lazy-ass')
 const is = require('check-more-types')
 const _ = require('lodash')
-const {Maybe} = require('ramda-fantasy')
-const {Just, Nothing} = Maybe
+const { Maybe } = require('ramda-fantasy')
+const { Just, Nothing } = Maybe
 const R = require('ramda')
-const {has, pathSatisfies, lt, tap, allPass} = R
+const { has, pathSatisfies, lt, tap, allPass } = R
 
 const positive = lt(0)
 const isObject = R.is(Object)
@@ -83,7 +83,7 @@ function setTestOrder (suite, tests, titles) {
 
   const orderedTests = []
   titles.forEach(title => {
-    const test = _.find(tests, { title: title })
+    const test = _.find(tests, { title })
     if (!test) {
       log('cannot find test under title', title, 'skipping')
       return


### PR DESCRIPTION
This rule is on its way into the latest Standard ☺️

ref: https://github.com/standard/eslint-config-standard/pull/166

Compatibility: This syntax works on Node.js 4.x and up, and this package declares Node.js 4.x as the minimum supported version ✅ 

-----

also fixed some spacing issues which was added in an earlier version of Standard :)

(btw. thank you for this package, I think it's great! 🙌)